### PR TITLE
fix series title

### DIFF
--- a/source/_posts/20200225-dynamodb-go1.md
+++ b/source/_posts/20200225-dynamodb-go1.md
@@ -1,4 +1,4 @@
-title: "Go×DynamoDB連載#1 GoでDynamoDBでおなじみのguregu/dynamoを利用する"
+title: "DynamoDB×Go連載#1 GoでDynamoDBでおなじみのguregu/dynamoを利用する"
 date: 2020/02/25 10:32:43
 tags:
   - Go
@@ -16,7 +16,7 @@ lede: "Go言語でWebサーバを実装していた際にDynamoDBを扱うライ
 
 当時Go初心者だった私は「go dynamo」とすぐさまGoogle先生に問い合わせ、「guregu/dynamoがオススメ」とのエントリーを多数発見しました。オブジェクトの取り回しが隠蔽化されていてとにかく実装が簡単だと記事にも書いてありましたし、私自身も実際そう感じました。
 
-すでにタイトルからお察しかと思いますが、本記事は連載第1回目です。時代の移ろいに合わせてGo×DynamoDB界隈の事情も刻一刻と変化しています。まずは私の利用していたSDK(guregu/dynamo)についてから本連載をスタートします。
+すでにタイトルからお察しかと思いますが、本記事は連載第1回目です。時代の移ろいに合わせてDynamoDB×Go界隈の事情も刻一刻と変化しています。まずは私の利用していたSDK(guregu/dynamo)についてから本連載をスタートします。
 
 # SDK(guregu/dynamo)を使ってDynamoDBへアクセスする
 
@@ -265,7 +265,7 @@ $ go run main.go
 
 続きはこちらです。
 
-* [Go×DynamoDB連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)
+* [DynamoDB×Go連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)
 
 ## 関連リンク
 

--- a/source/_posts/20200227-dynamodb-go2.md
+++ b/source/_posts/20200227-dynamodb-go2.md
@@ -1,4 +1,4 @@
-title: "Go×DynamoDB連載#2 AWS SDKによるDynamoDBの基本操作"
+title: "DynamoDB×Go連載#2 AWS SDKによるDynamoDBの基本操作"
 date: 2020/02/27 08:25:12
 tags:
   - Go
@@ -8,7 +8,7 @@ category:
   - Programming
 author: "武田大輝"
 featured: true
-lede: "Go×DynamoDB連載企画の第2弾の記事となります。本記事ではサードパーティ製のライブラリを利用せずaws-sdkを素で利用した場合のDynamoDBの基本操作について見ていきましょう。"
+lede: "DynamoDB×Go連載企画の第2弾の記事となります。本記事ではサードパーティ製のライブラリを利用せずaws-sdkを素で利用した場合のDynamoDBの基本操作について見ていきましょう。"
 ---
 
 こんにちは。TIG DXユニット[^1]の武田です。
@@ -17,8 +17,8 @@ lede: "Go×DynamoDB連載企画の第2弾の記事となります。本記事で
 
 ## はじめに
 
-[Go×DynamoDB連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)第2弾の記事となります。
-[Go×DynamoDB連載#1 GoでDynamoDBでおなじみのguregu/dynamoを利用する](https://future-architect.github.io/articles/20200225/) では [guregu/dynamo](https://github.com/guregu/dynamo) を利用したDynamoDBの基本操作をご紹介しました。
+[DynamoDB×Go連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)第2弾の記事となります。
+[DynamoDB×Go連載#1 GoでDynamoDBでおなじみのguregu/dynamoを利用する](https://future-architect.github.io/articles/20200225/) では [guregu/dynamo](https://github.com/guregu/dynamo) を利用したDynamoDBの基本操作をご紹介しました。
 
 本記事ではサードパーティ製のライブラリを利用せずaws-sdkを素で利用した場合のDynamoDBの基本操作について見ていきましょう。
 なお、公式のドキュメントは下記になりますので、より詳細な情報はこちらを参照してください。
@@ -286,7 +286,7 @@ gureguなどサードパーティ製のライブラリの利用と迷ってい�
 
 それでは、明日の投稿もお楽しみに。
 
-[Go×DynamoDB連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)以外にも多くの連載企画があります。特にGo Cloud連載が今回のテーマに近いです。
+[DynamoDB×Go連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)以外にも多くの連載企画があります。特にGo Cloud連載が今回のテーマに近いです。
 
 * [Go Cloud 連載](https://future-architect.github.io/tags/GoCDK/)
 * [GCP 連載](https://future-architect.github.io/tags/GCP%E9%80%A3%E8%BC%89/)

--- a/source/_posts/20200228-dynamodb-go-3.md
+++ b/source/_posts/20200228-dynamodb-go-3.md
@@ -332,7 +332,7 @@ DynamoDBのConditional Expressionsほど万能では無いですが、多くの�
 
 
 -----
-[Go×DynamoDB連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)以外にも多くの連載企画があります。特にGo Cloud連載が今回のテーマに近いです。
+[DynamoDB×Go連載企画](https://future-architect.github.io/tags/DynamoDB%C3%97Go/)以外にも多くの連載企画があります。特にGo Cloud連載が今回のテーマに近いです。
 
 * [Go Cloud 連載](https://future-architect.github.io/tags/GoCDK/)
 * [GCP 連載](https://future-architect.github.io/tags/GCP%E9%80%A3%E8%BC%89/)


### PR DESCRIPTION
「Go×DynamoDB」と「DynamoDB×Go」という表記が混在していました。
連載用のTag名として使われている、「DynamoDB×Go」で表記を統一しました。