### PR TITLE
t.Fatalの説明が誤っていたため修正

### DIFF
--- a/source/_posts/20200601-春祭り1-gotest.md
+++ b/source/_posts/20200601-春祭り1-gotest.md
@@ -142,7 +142,7 @@ PASS
 
 Go はテストのアサーションを提供していません。理由は公式の[FAQ](https://golang.org/doc/faq)で紹介されています。先程の `TestAddc` 関数のように、テストが失敗したことを開発者が自ら実装する必要があります。失敗したことを示すには [`T.Error (T.Errorf)`](https://golang.org/pkg/testing/#T.Error) や [`T.Fatal (T.Fatalf)`](https://golang.org/pkg/testing/#T.Fatal) を用いることができます。
 
-`T.Fatal` を用いると `T.Fatal` が実行された以降のテストは呼び出されずに終了します。`T.Cleanup` や `defer` を用いたテストの終了処理も実行されなくなります。テストが失敗したことを示すには `T.Error` を使い、テストの初期化など、処理が失敗するとその後のテストが無意味になる場合は `T.Fatal` を用いると良いでしょう。以下のようにテストが失敗した場合は、その後のテストの処理が呼び出されていないことが分かります。`defer` や `T.Cleanup` といった後処理は呼び出されます。
+`T.Fatal` を用いると `T.Fatal` が実行された以降のテストは呼び出されずに終了します。テストが失敗したことを示すには `T.Error` を使い、テストの初期化など、処理が失敗するとその後のテストが無意味になる場合は `T.Fatal` を用いると良いでしょう。以下のように `t.Fatalf` を用いた場合は、その後のテストの処理 `t.Log("after add() ...")` が呼び出されていないことが分かります。`defer` や `T.Cleanup` といった後処理は呼び出されます。
 
 ```go
 func TestAdd(t *testing.T) {
@@ -162,8 +162,12 @@ func TestAdd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// t.Fatalf でテストが失敗した場合でもクリーンアップ処理は呼び出される
 			t.Cleanup(func() {
-				t.Log("cleanup")
+				t.Log("cleanup!")
 			})
+
+			// t.Fatalf でテストが失敗した場合でも defer の処理は呼び出される
+			defer t.Log("defer!")
+
 			if got := add(tt.args.a, tt.args.b); got != tt.want {
 				t.Fatalf("add() = %v, want %v", got, tt.want)
 			}
@@ -178,20 +182,26 @@ func TestAdd(t *testing.T) {
 $ go test -v
 === RUN   TestAdd
 === RUN   TestAdd/fail
-    TestAdd/fail: main_test.go:28: add() = 3, want 30
-    TestAdd/fail: main_test.go:25: cleanup
+    diff_test.go:31: add() = 3, want 30
+    panic.go:617: defer!
+    diff_test.go:24: cleanup!
 === RUN   TestAdd/normal
-    TestAdd/normal: main_test.go:30: after add() ...
-    TestAdd/normal: main_test.go:25: cleanup
+    diff_test.go:34: after add() ...
+    diff_test.go:35: defer!
+    diff_test.go:24: cleanup!
 --- FAIL: TestAdd (0.00s)
     --- FAIL: TestAdd/fail (0.00s)
     --- PASS: TestAdd/normal (0.00s)
 FAIL
 exit status 1
-FAIL    github.com/d-tsuji/go-sandbox 0.177s
+FAIL    github.com/d-tsuji/go-sandbox 0.156s
 ```
 
-https://play.golang.org/p/CKVx9T1zvxt
+https://play.golang.org/p/2NZxz45zGD7
+
+なお `t.Fatalf` と似たような関数名でログ出力してアプリケーションを終了する `log` パッケージの [`Fatalf`](https://golang.org/pkg/log/#Fatalf) という関数があります。`log.Fatalf` のGo Docにもあるように `log.Fatalf` は `defer` といった後処理を呼び出さずに即座に `os.Exit(1)` でアプリケーションが終了します。`t.Fatalf` と `log.Fatalf` を混乱しないように注意しましょう。
+
+https://play.golang.org/p/ADm5xU7gsfm
 
 ## テストをスキップしたい
 


### PR DESCRIPTION
- [x] `t.Fatal` の説明の修正
- [x] `t.Fatalf` と `log.Fatalf` の終了時の挙動の差異を追記