### PR TITLE
Fix W3C HTML Validate error

### DIFF
--- a/themes/corporate/layout/_partial/footer.ejs
+++ b/themes/corporate/layout/_partial/footer.ejs
@@ -31,7 +31,7 @@
     }(document, 'script', 'facebook-jssdk'));</script>
 
   <!-- Pocket Shareボタン. ページ毎に1度初期化できれば良いのでフッターに配備 -->
-  <script type="text/javascript">!function(d,i){if(!d.getElementById(i)){var j=d.createElement("script");j.id=i;j.src="https://widgets.getpocket.com/v1/j/btn.js?v=1";var w=d.getElementById(i);d.body.appendChild(j);}}(document,"pocket-btn-js");</script>
+  <script>!function(d,i){if(!d.getElementById(i)){var j=d.createElement("script");j.id=i;j.src="https://widgets.getpocket.com/v1/j/btn.js?v=1";var w=d.getElementById(i);d.body.appendChild(j);}}(document,"pocket-btn-js");</script>
   <!-- Twitter Shareボタン. ページ毎に1度初期化できれば良いのでフッターに配備 -->
   <script>window.twttr = (function(d, s, id) {
     var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {};
@@ -49,7 +49,7 @@
   }(document, "script", "twitter-wjs"));</script>
 
   <!-- はてぶ Shareボタン. ページ毎に1度初期化できれば良いのでフッターに配備 -->
-  <script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+  <script src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
 
 	<% if (theme.twitter_widget_id){ %>
     <!-- BEGIN TWITTER BLOCK -->

--- a/themes/corporate/layout/_partial/footer.ejs
+++ b/themes/corporate/layout/_partial/footer.ejs
@@ -49,7 +49,7 @@
   }(document, "script", "twitter-wjs"));</script>
 
   <!-- はてぶ Shareボタン. ページ毎に1度初期化できれば良いのでフッターに配備 -->
-  <script src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+  <script src="https://b.st-hatena.com/js/bookmark_button.js" async="async"></script>
 
 	<% if (theme.twitter_widget_id){ %>
     <!-- BEGIN TWITTER BLOCK -->

--- a/themes/corporate/layout/_partial/google-analytics.ejs
+++ b/themes/corporate/layout/_partial/google-analytics.ejs
@@ -1,6 +1,6 @@
 <% if (theme.google_analytics){ %>
 <!-- Google Analytics -->
-<script type="text/javascript">
+<script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/themes/corporate/layout/_partial/scripts.ejs
+++ b/themes/corporate/layout/_partial/scripts.ejs
@@ -3,7 +3,7 @@
 <script src="/metronic/assets/plugins/bootstrap/js/bootstrap.min.js"></script>
 <script src="/metronic/assets/corporate/scripts/layout.js"></script>
 
-<script type="text/javascript">
+<script>
     jQuery(document).ready(function() {
         Layout.init();
     });


### PR DESCRIPTION
* The type attribute is unnecessary for JavaScript resources.
* The charset attribute on the script element is obsolete.
* The itemprop attribute was specified, but the element is not a property of any item.