### PR TITLE
#640 注目の記事に日付を追加

### DIFF
--- a/scripts/featured_post.js
+++ b/scripts/featured_post.js
@@ -7,7 +7,7 @@ hexo.extend.helper.register('featured_posts', function(rate) {
     ;
 
   const links = featureds.map(post => `
-    <li><a href="/${post.path}" title="${post.lede}">${post.title}</a></li>`).join("\n")
+    <li>${post.date.format('YYYY.MM.DD')}<a href="/${post.path}" title="${post.lede}">${post.title}</a></li>`).join("\n")
 
   return `
   <div class="widget">


### PR DESCRIPTION
#640

* 悩んだが、日付を親に持ってきた
    * 記事タイトルの後ろに持ってくるかどうかは後日検討
* フォーマットは yyyy.mm.dd にした（いつくかのニュースサイトを参考）