### PR TITLE
#662 details,summaryタグのCSS調整

### DIFF
--- a/themes/corporate/source/metronic/assets/corporate/css/style.css
+++ b/themes/corporate/source/metronic/assets/corporate/css/style.css
@@ -1118,3 +1118,15 @@ Notes
 @media (max-width:320px){
   .site-logo{margin-right:0}
 }
+
+/* 折りたたみ */
+summary {
+  padding-top: 10px;
+  cursor: pointer;
+}
+summary:hover {
+  color: #129299;
+}
+details {
+  padding-bottom: 24px;
+}


### PR DESCRIPTION
* #662

# 修正サンプル

スクリーンショットでポインタが消えているが、ポインタもでている。

![image](https://user-images.githubusercontent.com/1751238/117947170-e708d680-b34a-11eb-8f0e-7cf789ad3af7.png)
