### PR TITLE
#703 Twitterフォローボタンのulがないiタグを修正

### DIFF
--- a/themes/corporate/layout/_partial/footer.ejs
+++ b/themes/corporate/layout/_partial/footer.ejs
@@ -36,11 +36,11 @@
             <!-- BEGIN TWITTER BLOCK -->
             <div class="col-md-4 col-sm-6 pre-footer-col">
               <!-- Twitterフォローボタン -->
-              <li class="twitter-btn">
+              <div class="twitter-btn twitter-follow-btn">
                 <a href="https://twitter.com/intent/follow?screen_name=future_techblog %>" target="_blank" rel="nofollow noopener">
                   <i></i><span class="tw-btn-label">@future_techblogさんをフォロー</span>
                 </a>
-              </li>
+              </div>
               <!-- Twitterタイムライン -->
               <a data-tweet-limit="1" class="twitter-timeline" href="https://twitter.com/<%= theme.twitter_username %>?ref_src=<%= theme.twitter_widget_id %>" data-lang="ja" data-dnt="true">Tweets by @<%= theme.twitter_username %></a>
             </div>

--- a/themes/corporate/source/css/theme-styles.styl
+++ b/themes/corporate/source/css/theme-styles.styl
@@ -431,6 +431,7 @@ ul.social-button li a {
   border-radius: 3px;
   border: 1px solid #1b95e0;
 }
+
 .twitter-btn i {
   top: 2px;
   position: relative;
@@ -448,6 +449,9 @@ ul.social-button li a {
   display: inline-block;
   margin-left: 6px;
   white-space: nowrap;
+}
+.twitter-follow-btn {
+  margin-bottom: 6px;
 }
 
 /* Custom Facebook Button */


### PR DESCRIPTION
* #703

# After

以下のように改善された。

![image](https://user-images.githubusercontent.com/1751238/118500720-fe88fa80-b762-11eb-9cd9-231b0e32e0f3.png)

見た目は同じ。

![image](https://user-images.githubusercontent.com/1751238/118500847-1a8c9c00-b763-11eb-9804-cfad462ecd9d.png)
