### PR TITLE
#705 window.openの設定を削除

### DIFF
--- a/cache_hatebu.json
+++ b/cache_hatebu.json
@@ -172,7 +172,7 @@
   "https://future-architect.github.io/articles/20200827/": 1,
   "https://future-architect.github.io/articles/20200824/": 2,
   "https://future-architect.github.io/articles/20200820/": 5,
-  "https://future-architect.github.io/articles/20200821/": 13,
+  "https://future-architect.github.io/articles/20200821/": 14,
   "https://future-architect.github.io/articles/20200819/": 8,
   "https://future-architect.github.io/articles/20200818/": 6,
   "https://future-architect.github.io/articles/20200817/": 0,

--- a/cache_pocket.json
+++ b/cache_pocket.json
@@ -137,7 +137,7 @@
   "https://future-architect.github.io/articles/20201027/": 2,
   "https://future-architect.github.io/articles/20201026/": 1,
   "https://future-architect.github.io/articles/20201022/": 6,
-  "https://future-architect.github.io/articles/20201020/": 72,
+  "https://future-architect.github.io/articles/20201020/": 73,
   "https://future-architect.github.io/articles/20201021/": 1,
   "https://future-architect.github.io/articles/20201015/": 0,
   "https://future-architect.github.io/articles/20201013/": 138,

--- a/themes/corporate/layout/_partial/social-button.ejs
+++ b/themes/corporate/layout/_partial/social-button.ejs
@@ -11,29 +11,25 @@
     %>
     <!-- Twitter -->
     <li class="twitter-btn">
-      <a href="https://twitter.com/share?url=<%- link %>&via=future_techblog&related=twitterapi%2Ctwitter&text=<%- encodeURI(title) %>"
-        onclick="window.open(this.href, 'tweetwindow', 'width=650, height=470, personalbar=0, toolbar=0, scrollbars=1, sizable=1'); return false;" rel="nofollow">
+      <a href="https://twitter.com/share?url=<%- link %>&via=future_techblog&related=twitterapi%2Ctwitter&text=<%- encodeURI(title) %>" rel="nofollow">
         <i></i><span class="tw-btn-label"><%= get_tw_count(link) %></span>
       </a>
     </li>
     <!-- Facebook -->
     <li class="fb-btn">
-      <a href="http://www.facebook.com/share.php?u=<%- link %>&t=<%- encodeURI(title) %>"
-        onclick="window.open(this.href, 'fbsharewindow', 'width=650, height=470, personalbar=0, toolbar=0, scrollbars=1, sizable=1'); return false;" rel="nofollow">
+      <a href="http://www.facebook.com/share.php?u=<%- link %>&t=<%- encodeURI(title) %>" rel="nofollow">
         <i></i><span class="fb-btn-label"><%= get_fb_count(link) %></span>
       </a>
     </li>
     <!-- hatebu -->
     <li class="hatebu-btn">
-      <a href="https://b.hatena.ne.jp/entry/s/<%- encodeURI(link).replace('https://', '') %>"
-        onclick="window.open(this.href, 'hatebuwindow', 'width=650, height=470, personalbar=0, toolbar=0, scrollbars=1, sizable=1'); return false;" rel="nofollow">
+      <a href="https://b.hatena.ne.jp/entry/s/<%- encodeURI(link).replace('https://', '') %>" rel="nofollow">
         <i></i><span class="hatebu-btn-label"><%= get_hatebu_count(link) %></span>
       </a>
     </li>
     <!-- pocket -->
     <li class="pocket-btn">
-      <a href="https://getpocket.com/save?url=<%- encodeURI(link) %>"
-        onclick="window.open(this.href, 'pocketwindow', 'width=650, height=470, personalbar=0, toolbar=0, scrollbars=1, sizable=1'); return false;" rel="nofollow">
+      <a href="https://getpocket.com/save?url=<%- encodeURI(link) %>" rel="nofollow">
         <i></i><span class="pocket-btn-label"><%= get_pocket_count(link) %></span>
       </a>
     </li>


### PR DESCRIPTION
#705

* PC
* モバイル

で動作確認したが、別タブの方がアプリ遷移後も戻るボタンでサイトに復帰できるのでユーザビリティが高いと判断