### PR TITLE
[suggestion]ブログタイトルにマウスオーバーした際にアンダーラインを表示しない

### DIFF
--- a/themes/corporate/source/css/theme-styles.styl
+++ b/themes/corporate/source/css/theme-styles.styl
@@ -317,6 +317,7 @@ body.page-header-fixed .header {
 
 .header-title a{
   color: #ddd;
+  text-decoration: none;
 }
 
 .header-title-sub {


### PR DESCRIPTION
ブログタイトルへのマウスオーバー時に出る下線(aタグのデフォルトの挙動)が出ないほうが見栄えが良いかなという提案です

![image](https://user-images.githubusercontent.com/49754654/119267738-d437b100-bc2a-11eb-955b-3e7520da6aef.png)


![image](https://user-images.githubusercontent.com/49754654/119267725-cb46df80-bc2a-11eb-8b02-b857dc942638.png)
