### PR TITLE
件数調整

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,14 @@ author_generator:
   per_page: 10
   url_map:
 
+category_generator:
+  per_page: 10
+  order_by: -date
+
+tag_generator:
+  per_page: 10
+  order_by: -date
+
 # Writing
 new_post_name: :title.md # File name of new posts
 default_layout: post


### PR DESCRIPTION
/articles のページングを1000（実質なし）にした影響で、 category, tagのページングが無くなっていたので、コンフィグに設定を追加