### PR TITLE
#846 モバイルでの表示ズレを修正

### DIFF
--- a/themes/corporate/source/css/theme-styles.styl
+++ b/themes/corporate/source/css/theme-styles.styl
@@ -624,6 +624,10 @@ code {
   }
 }
 
+.article-list {
+  padding-inline-start: 0px;
+}
+
 .article-list li {
   list-style: none;
   margin-bottom: 8px;


### PR DESCRIPTION
#846 

# Before

余計なpaddingがあった

![image](https://user-images.githubusercontent.com/1751238/120098846-2caf0700-c173-11eb-807b-8c865f6b19b4.png)


# After

![image](https://user-images.githubusercontent.com/1751238/120098841-228d0880-c173-11eb-9f20-d44e22e8357a.png)
