### PR TITLE
#950 サムネイル画像のマウスオーバーで画像を目立たせる対応

### DIFF
--- a/themes/corporate/layout/_partial/archive-post.ejs
+++ b/themes/corporate/layout/_partial/archive-post.ejs
@@ -1,6 +1,6 @@
 <div class="row card">
   <a href="<%- url_for(post.path) %>">
-    <div class="col-md-4 col-sm-4">
+    <div class="col-md-4 col-sm-4 img_wrap">
       <% if (post.thumbnail) { %>
       <img src="<%= post.thumbnail %>" class="img-responsive" alt="" <%= image_size_attribute(post.thumbnail) %> loading="lazy">
       <% } %>

--- a/themes/corporate/source/css/theme-styles.styl
+++ b/themes/corporate/source/css/theme-styles.styl
@@ -143,6 +143,18 @@ h4 {
 .blog-item .img-reset-size {
   width: initial;
 }
+.img_wrap {
+  overflow: hidden;
+}
+.img_wrap img{
+  width: 100%;
+  cursor: pointer;
+  transition-duration: 0.3s;
+}
+.img_wrap:hover img{
+  opacity: 0.6;
+  transition-duration: 0.3s;
+}
 
 .image-strip {
   max-height: 300px;


### PR DESCRIPTION
#950

# before
![image](https://user-images.githubusercontent.com/1751238/122189477-eb855980-cecb-11eb-8a7a-d1112996fa49.png)


# after
![image](https://user-images.githubusercontent.com/1751238/122189450-e6280f00-cecb-11eb-820f-d7940caf8b49.png)

