### PR TITLE
Update 20220210a_Go_1.18集中連載_net／httpのマイナーチェンジ.md

### DIFF
--- a/source/_posts/20220210a_Go_1.18集中連載_net／httpのマイナーチェンジ.md
+++ b/source/_posts/20220210a_Go_1.18集中連載_net／httpのマイナーチェンジ.md
@@ -205,7 +205,7 @@ https://github.com/golang/go/blob/master/src/net/http/cookie.go#L288-L303
 すでにいくつかのブログで紹介されていました。詳しい..。
 
 * [Big Sky :: Go の http パッケージに MaxBytesHandler が入った。](https://mattn.kaoriya.net/software/lang/go/20211224005655.htm)
-* [go1.18で入ったhttp.MaxBytesHandlerの中身を見てみた](https://qiita.com/drafts/8631ca372866a1b32720/edit)
+* [go1.18で入ったhttp.MaxBytesHandlerの中身を見てみた](https://zenn.dev/hiroyukim/articles/4b4f5b482c0c2d)
 
 こういったストリームの読み取り時は、io.CopyN() を使ってまるごと読み取らないようにしようよといったお決まりがありましたが、それがさらに標準化されたのは良い流れかなと思います。ぜひ使っていきましょう。
 


### PR DESCRIPTION
リンク先が間違っているようです